### PR TITLE
Added timeout to unused state

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,6 +29,8 @@ libraryDependencies += "org.slf4j" % "log4j-over-slf4j" % "1.6.6" % "provided"
 
 parallelExecution in Test := false
 
+fork := true
+
 pomExtra := (
   <url>http://github.com/sclasen/akka-kafka</url>
     <licenses>

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,6 +6,6 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.1")
 
 resolvers += "sbt-idea-repo" at "http://mpeltonen.github.com/maven/"
 
-addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.5.2")
+addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.6.0")
 
 

--- a/src/it/scala/com/sclasen/akka/kafka/AkkaConsumerSpec.scala
+++ b/src/it/scala/com/sclasen/akka/kafka/AkkaConsumerSpec.scala
@@ -137,6 +137,6 @@ class TestReceiver(testActor: ActorRef) extends Actor {
       sender ! Processed
       testActor ! m
   }
-}
+
 }
 

--- a/src/it/scala/com/sclasen/akka/kafka/AkkaConsumerSpec.scala
+++ b/src/it/scala/com/sclasen/akka/kafka/AkkaConsumerSpec.scala
@@ -131,7 +131,7 @@ object AkkaConsumerSpec {
 
 }
 
-class TestReciever(testActor: ActorRef) extends Actor {
+class TestReceiver(testActor: ActorRef) extends Actor {
   override def receive = {
     case m: Any =>
       sender ! Processed

--- a/src/it/scala/com/sclasen/akka/kafka/AkkaConsumerSpec.scala
+++ b/src/it/scala/com/sclasen/akka/kafka/AkkaConsumerSpec.scala
@@ -32,7 +32,7 @@ with WordSpecLike with Matchers with BeforeAndAfterAll {
 
   "AkkaConsumer" should {
     "work with a topic" in {
-      val receiver = system.actorOf(Props(new TestReciever(testActor)))
+      val receiver = system.actorOf(Props(new TestReceiver(testActor)))
       val consumer = new AkkaConsumer(testProps(system, singleTopic, receiver))
       doTest(singleTopic, consumer)
       consumer.stop() pipeTo testActor
@@ -42,7 +42,7 @@ with WordSpecLike with Matchers with BeforeAndAfterAll {
 
   "AkkaConsumer with TopicFilter" should {
     "work with a topicFilter" in {
-      val receiver = system.actorOf(Props(new TestReciever(testActor)))
+      val receiver = system.actorOf(Props(new TestReceiver(testActor)))
       val consumer = new AkkaConsumer(testProps(system, new Blacklist("^test.*"), receiver))
       doTest(topicFilter, consumer)
       consumer.stop() pipeTo testActor
@@ -137,5 +137,6 @@ class TestReceiver(testActor: ActorRef) extends Actor {
       sender ! Processed
       testActor ! m
   }
+}
 }
 

--- a/src/main/scala/com/sclasen/akka/kafka/AkkaConsumer.scala
+++ b/src/main/scala/com/sclasen/akka/kafka/AkkaConsumer.scala
@@ -86,8 +86,9 @@ object AkkaConsumerProps {
                       connectorActorName:Option[String] = None,
                       maxInFlightPerStream: Int = 64,
                       startTimeout: Timeout = Timeout(5 seconds),
-                      commitConfig: CommitConfig = CommitConfig()): AkkaConsumerProps[Key, Msg] =
-    AkkaConsumerProps(system, system, zkConnect, Right(topic), group, streams, keyDecoder, msgDecoder, msgHandler, receiver, connectorActorName, maxInFlightPerStream, startTimeout, commitConfig)
+                      commitConfig: CommitConfig = CommitConfig(),
+                      unusedTimeout: FiniteDuration= 5 seconds): AkkaConsumerProps[Key, Msg] =
+    AkkaConsumerProps(system, system, zkConnect, Right(topic), group, streams, keyDecoder, msgDecoder, msgHandler, receiver, connectorActorName, maxInFlightPerStream, startTimeout, commitConfig, unusedTimeout)
 
   def forSystemWithFilter[Key, Msg](system: ActorSystem,
                           zkConnect: String,
@@ -101,8 +102,9 @@ object AkkaConsumerProps {
                           connectorActorName:Option[String] = None,
                           maxInFlightPerStream: Int = 64,
                           startTimeout: Timeout = Timeout(5 seconds),
-                          commitConfig: CommitConfig = CommitConfig()): AkkaConsumerProps[Key, Msg] =
-    AkkaConsumerProps(system, system, zkConnect, Left(topicFilter), group, streams, keyDecoder, msgDecoder, msgHandler, receiver, connectorActorName, maxInFlightPerStream, startTimeout, commitConfig)
+                          commitConfig: CommitConfig = CommitConfig(),
+                          unusedTimeout: FiniteDuration= 5 seconds): AkkaConsumerProps[Key, Msg] =
+    AkkaConsumerProps(system, system, zkConnect, Left(topicFilter), group, streams, keyDecoder, msgDecoder, msgHandler, receiver, connectorActorName, maxInFlightPerStream, startTimeout, commitConfig,unusedTimeout)
 
 
   def forContext[Key, Msg](context: ActorContext,
@@ -117,8 +119,9 @@ object AkkaConsumerProps {
                       connectorActorName:Option[String] = None,
                       maxInFlightPerStream: Int = 64,
                       startTimeout: Timeout = Timeout(5 seconds),
-                      commitConfig: CommitConfig): AkkaConsumerProps[Key, Msg] =
-    AkkaConsumerProps(context.system, context, zkConnect, Right(topic), group, streams, keyDecoder, msgDecoder, msgHandler, receiver,connectorActorName, maxInFlightPerStream, startTimeout, commitConfig)
+                      commitConfig: CommitConfig,
+                      unusedTimeout: FiniteDuration= 5 seconds): AkkaConsumerProps[Key, Msg] =
+    AkkaConsumerProps(context.system, context, zkConnect, Right(topic), group, streams, keyDecoder, msgDecoder, msgHandler, receiver,connectorActorName, maxInFlightPerStream, startTimeout, commitConfig, unusedTimeout)
 
   def forContextWithFilter[Key, Msg](context: ActorContext,
                            zkConnect: String,
@@ -132,8 +135,9 @@ object AkkaConsumerProps {
                            connectorActorName:Option[String] = None,
                            maxInFlightPerStream: Int = 64,
                            startTimeout: Timeout = Timeout(5 seconds),
-                           commitConfig: CommitConfig): AkkaConsumerProps[Key, Msg] =
-    AkkaConsumerProps(context.system, context, zkConnect, Left(topicFilter), group, streams, keyDecoder, msgDecoder, msgHandler, receiver,connectorActorName, maxInFlightPerStream, startTimeout, commitConfig)
+                           commitConfig: CommitConfig,
+                           unusedTimeout: FiniteDuration = 5 seconds): AkkaConsumerProps[Key, Msg] =
+    AkkaConsumerProps(context.system, context, zkConnect, Left(topicFilter), group, streams, keyDecoder, msgDecoder, msgHandler, receiver,connectorActorName, maxInFlightPerStream, startTimeout, commitConfig, unusedTimeout)
 
   def defaultHandler[Key,Msg]: (MessageAndMetadata[Key,Msg]) => Any = msg => msg.message()
 }
@@ -151,7 +155,8 @@ case class AkkaConsumerProps[Key,Msg](system:ActorSystem,
                                       connectorActorName:Option[String],
                                       maxInFlightPerStream:Int = 64,
                                       startTimeout:Timeout = Timeout(5 seconds),
-                                      commitConfig:CommitConfig = CommitConfig())
+                                      commitConfig:CommitConfig = CommitConfig(),
+                                      unusedTimeout: FiniteDuration= 5 seconds)
 
 case class CommitConfig(commitInterval:Option[FiniteDuration] = Some(10 seconds),
                         commitAfterMsgCount:Option[Int] = Some(10000),


### PR DESCRIPTION
This commit solves the problem when kafka and the consumer is not commiting and goes to the unused state. 
Please let me know if I can improve anything in the code.
After this commit is accepted  I want to merge this change with the kafka-082 branch and do some upgrade on the akka libraries.
