### PR TITLE
fixed typo: recieve -> receive

### DIFF
--- a/src/it/scala/com/sclasen/akka/kafka/AkkaBatchConsumerSpec.scala
+++ b/src/it/scala/com/sclasen/akka/kafka/AkkaBatchConsumerSpec.scala
@@ -32,7 +32,7 @@ with WordSpecLike with Matchers with BeforeAndAfterAll {
 
   "AkkaConsumer" should {
     "work with a topic" in {
-      val receiver = system.actorOf(Props(new TestBatchReciever(testActor)))
+      val receiver = system.actorOf(Props(new TestBatchReceiver(testActor)))
       val consumer = new AkkaBatchConsumer(testProps(system, singleTopic, receiver))
       doTest(singleTopic, consumer)
       consumer.stop() pipeTo testActor
@@ -47,7 +47,7 @@ with WordSpecLike with Matchers with BeforeAndAfterAll {
     }
     expectMsg(2 seconds, BatchConnectorFSM.Started)
 
-    /*test that we are ok after a recieve timeout*/
+    /*test that we are ok after a receive timeout*/
     expectNoMsg()
 
     (1 to 10).foreach {
@@ -132,7 +132,7 @@ object AkkaBatchConsumerSpec {
 
 }
 
-class TestBatchReciever(testActor: ActorRef) extends Actor {
+class TestBatchReceiver(testActor: ActorRef) extends Actor {
   override def receive = {
     case s: SpecificallyTypedBatch =>
       sender ! BatchProcessed

--- a/src/it/scala/com/sclasen/akka/kafka/AkkaConsumerSpec.scala
+++ b/src/it/scala/com/sclasen/akka/kafka/AkkaConsumerSpec.scala
@@ -32,7 +32,7 @@ with WordSpecLike with Matchers with BeforeAndAfterAll {
 
   "AkkaConsumer" should {
     "work with a topic" in {
-      val receiver = system.actorOf(Props(new TestReciever(testActor)))
+      val receiver = system.actorOf(Props(new TestReceiver(testActor)))
       val consumer = new AkkaConsumer(testProps(system, singleTopic, receiver))
       doTest(singleTopic, consumer)
       consumer.stop() pipeTo testActor
@@ -42,7 +42,7 @@ with WordSpecLike with Matchers with BeforeAndAfterAll {
 
   "AkkaConsumer with TopicFilter" should {
     "work with a topicFilter" in {
-      val receiver = system.actorOf(Props(new TestReciever(testActor)))
+      val receiver = system.actorOf(Props(new TestReceiver(testActor)))
       val consumer = new AkkaConsumer(testProps(system, new Blacklist("^test.*"), receiver))
       doTest(topicFilter, consumer)
       consumer.stop() pipeTo testActor
@@ -131,7 +131,7 @@ object AkkaConsumerSpec {
 
 }
 
-class TestReciever(testActor: ActorRef) extends Actor {
+class TestReceiver(testActor: ActorRef) extends Actor {
   override def receive = {
     case m: Any =>
       sender ! Processed

--- a/src/it/scala/com/sclasen/akka/kafka/AkkaDirectConsumerSpec.scala
+++ b/src/it/scala/com/sclasen/akka/kafka/AkkaDirectConsumerSpec.scala
@@ -27,7 +27,7 @@ class AkkaDirectConsumerSpec(_system: ActorSystem) extends TestKit(_system) with
 
   "AkkaDirectConsumer" should {
     "work with a topic" in {
-      val receiver = system.actorOf(Props(new TestReciever(testActor)))
+      val receiver = system.actorOf(Props(new TestReceiver(testActor)))
       val consumer = new AkkaDirectConsumer(testProps(system, singleTopic, receiver))
       doTest(singleTopic, consumer)
       consumer.stop() pipeTo testActor

--- a/src/it/scala/com/sclasen/akka/kafka/NonCommitingConsumerSpec.scala
+++ b/src/it/scala/com/sclasen/akka/kafka/NonCommitingConsumerSpec.scala
@@ -28,7 +28,7 @@ with WordSpecLike with Matchers with BeforeAndAfterAll {
 
   "AkkaConsumer with Non Committing config" should {
     "work with a topic" in {
-      val receiver = system.actorOf(Props(new TestReciever(testActor)))
+      val receiver = system.actorOf(Props(new TestReceiver(testActor)))
       val consumer = new AkkaConsumer(testProps(system, singleTopic, receiver))
       doTest(singleTopic, consumer)
       consumer.stop() pipeTo testActor

--- a/src/main/scala/com/sclasen/akka/kafka/BatchActors.scala
+++ b/src/main/scala/com/sclasen/akka/kafka/BatchActors.scala
@@ -110,7 +110,7 @@ class BatchConnectorFSM[Key, Msg, Out:ClassTag, BatchOut](props: AkkaBatchConsum
       stay() using outstanding + props.streams
     case Event(StateTimeout, outstanding) =>
       debugRec(StateTimeout, 0, outstanding)
-      log.info("at=recieve-timeout outstanding={} batch-size={}", outstanding, batch.size)
+      log.info("at=receive-timeout outstanding={} batch-size={}", outstanding, batch.size)
       goto(WaitingToSendBatch)
   }
 


### PR DESCRIPTION
Simple fix of a typo (`at=recieve-timeout`) in batch actor.
